### PR TITLE
git fix added for the cloning since the branch is not set to master b…

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -11,7 +11,7 @@ Download and build
 
 .. code-block:: json
 
-    > git clone https://github.com/tronprotocol/java-tron.git
+    > git clone -b master https://github.com/tronprotocol/java-tron.git
     > cd java-tron
     > gradle build
 
@@ -19,7 +19,7 @@ Download and build
 
 .. code-block:: json
 
-    > git clone https://github.com/tronprotocol/java-tron.git
+    > git clone -b master https://github.com/tronprotocol/java-tron.git
     > cd java-tron
     > ./gradlew clean shadowJar
     > java -jar java-tron/build/libs/java-tron.jar


### PR DESCRIPTION
The following command is failing 
> git clone  https://github.com/tronprotocol/java-tron.git
since the default branch is not set to master in the tronprotocol repo
> git clone  -b master https://github.com/tronprotocol/java-tron.git 
is working 
 